### PR TITLE
github filetype detect fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.um linguist-language=umka


### PR DESCRIPTION
this fixes the "1.6% Rust" stat by overriding the vim modeline in your umka file