### PR TITLE
Bump umka. Fix pomodoro app. Fix font measuring and rendering.

### DIFF
--- a/examples/pomodoro/main.um
+++ b/examples/pomodoro/main.um
@@ -297,17 +297,13 @@ fn formatTime(time: real): str {
   minutes := trunc(time / 60)%60
   seconds := trunc(time)%60
 
-  buf := str(make([]char, 256))
-
   if hours > 0 {
-    sprintf(buf, "%d:%02d:%02d", hours, minutes, seconds)
+    return sprintf("%d:%02d:%02d", hours, minutes, seconds)
   } else if minutes > 0 {
-    sprintf(buf, "%d:%02d", minutes, seconds)
-  } else {
-    sprintf(buf, "0:%02d", seconds)
+    return sprintf("%d:%02d", minutes, seconds)
   }
 
-  return buf
+	return sprintf("0:%02d", seconds)
 }
 
 //


### PR DESCRIPTION
* General:
  * Bump Umka. 
* Pomodoro:
  * Fix usage of old sprintf function. 
* Font:
  * Measuring newlines now accounts descent.
  * Trailing newlines (At the end of string) are now accounted in measurements.
 